### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,16 @@ branches:
 matrix:
     fast_finish: true
     include:
+        - php: 7.4
+        - php: 7.3
+        - php: 7.2
         - php: 7.1
         - php: 7.0
         - php: 5.6
         - php: 5.5
-        - php: hhvm
-          sudo: required
           dist: trusty
-          group: edge
 
 before_install:
-    - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then echo 'xdebug.enable = on' >> /etc/hhvm/php.ini; fi
     - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "^4.8.36",
         "scrutinizer/ocular": "~1.3",
-        "satooshi/php-coveralls": "^1.0"
+        "php-coveralls/php-coveralls": "^1.0"
     }
 }

--- a/tests/ImageMetaAnalyzerTest.php
+++ b/tests/ImageMetaAnalyzerTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\ImageMeta\Tests;
 
 use GpsLab\Component\ImageMeta\ImageMetaAnalyzer;
+use PHPUnit\Framework\TestCase;
 
-class ImageMetaAnalyzerTest extends \PHPUnit_Framework_TestCase
+class ImageMetaAnalyzerTest extends TestCase
 {
     /**
      * @var ImageMetaAnalyzer

--- a/tests/ImageMetadataTest.php
+++ b/tests/ImageMetadataTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\ImageMeta\Tests;
 
 use GpsLab\Component\ImageMeta\ImageMetadata;
+use PHPUnit\Framework\TestCase;
 
-class ImageMetadataTest extends \PHPUnit_Framework_TestCase
+class ImageMetadataTest extends TestCase
 {
     public function testGetters()
     {


### PR DESCRIPTION
# Changed log
- The `hhvm` version will be different from `php-7.x`. Removing them is proper.
- `satooshi/php-coveralls` package is deprecated, using the `php-coveralls/php-coveralls` instead.
- The Travis CI build dist is `xenial` by default and the `php-5.5` version is not included on this dist.
Adding the `trusty` dist for this version.
- To be compatible with future PHPUnit version, using the `^4.8.36` version and `PHPUnit\Framework\TestCase` namespace.